### PR TITLE
Compatibility with ggplot2

### DIFF
--- a/tests/testthat/test-plotCor.R
+++ b/tests/testthat/test-plotCor.R
@@ -2,8 +2,13 @@ p <- plotCor(SDMtune:::t, cor_th = .8, text_size = 4)
 
 test_that("The plot has the correct labels and text size", {
   expect_equal(p$plot_env$label, "Spearman's\ncoefficient")
-  expect_equal(p$labels$x, "Var2")
-  expect_equal(p$labels$y, "Var1")
+  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    ggplot2::get_labs(p)
+  } else {
+    p$labels
+  }
+  expect_equal(labels$x, "Var2")
+  expect_equal(labels$y, "Var1")
   expect_equal(p$layers[[2]]$aes_params$size, 4)
 })
 


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the SDMtune package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
In addition, I saw some snapshots might need updating but that isn't included in this PR.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun